### PR TITLE
Add support for MSM8952 and Xiaomi Redmi 4X (santoni)

### DIFF
--- a/dts/msm8940-xiaomi-santoni.dts
+++ b/dts/msm8940-xiaomi-santoni.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2020 - Dreemurrs Embedded Labs
+
+/dts-v1/;
+
+/include/ "msm8952.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB 
+	qcom,msm-id = <313 0x0>;
+	qcom,board-id = <0x1000b 1>, <0x2000b 1>;
+
+	model = "Xiaomi Redmi 4X (santoni)";
+	compatible = "xiaomi,santoni", "qcom,msm8940", "lk2nd,device";
+
+	// Bootloader won't continue if it can't delete some nodes from below
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 0x0 0xffffffff>;
+
+	};
+};

--- a/dts/msm8952.dtsi
+++ b/dts/msm8952.dtsi
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	// The bootloader gets really sad if it cannot find those nodes
+	soc { };
+	chosen { };
+
+	memory {
+		device_type = "memory";
+		/* We expect the bootloader to fill in the reg */
+		reg = <0 0 0 0>;
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -15,3 +15,7 @@ DTBS += \
 	$(LOCAL_DIR)/sdm450-samsung-r04.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-mido.dtb
 endif
+ifeq ($(PROJECT), msm8952-secondary)
+DTBS += \
+	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb
+endif

--- a/project/msm8952-secondary.mk
+++ b/project/msm8952-secondary.mk
@@ -1,0 +1,31 @@
+# top level project rules for the msm8952 project
+#
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+OUTBOOTIMG := $(BUILDDIR)/lk2nd.img
+
+# Enable fastboot display menu
+ENABLE_FBCON_DISPLAY_MSG := 1
+
+include $(LOCAL_DIR)/msm8952.mk
+
+#  maximum verbosity
+BOARD_NAME := msm8952-secondary
+CFLAGS += -Wno-error
+DEBUG := 2
+DEFINES += LK_LOG_BUF_SIZE=16384
+
+# Avoid writing device info
+DEFINES += SAFE_MODE=1
+# Display as unlocked by default
+DEFINES += DEFAULT_UNLOCK=1
+
+DEFINES += DISPLAY_SPLASH_SCREEN=1
+
+# Use continuous splash from primary bootloader for display
+DISPLAY_USE_CONTINUOUS_SPLASH := 1
+TARGET_USES_APPENDED_DTBS := 1
+
+APPSBOOTHEADER: $(OUTBOOTIMG)
+ANDROID_BOOT_BASE := 0x80000000
+ANDROID_BOOT_CMDLINE := lk2nd

--- a/target/msm8952/rules.mk
+++ b/target/msm8952/rules.mk
@@ -49,8 +49,11 @@ DEFINES += \
 OBJS += \
 	$(LOCAL_DIR)/init.o \
 	$(LOCAL_DIR)/meminfo.o \
-	$(LOCAL_DIR)/target_display.o \
 	$(LOCAL_DIR)/oem_panel.o
+ifneq ($(DISPLAY_USE_CONTINUOUS_SPLASH),1)
+OBJS += \
+	$(LOCAL_DIR)/target_display.o
+endif
 ifeq ($(ENABLE_SMD_SUPPORT),1)
 OBJS += \
 	$(LOCAL_DIR)/regulator.o


### PR DESCRIPTION
Redmi 4X is MSM8940, however it is compatible with MSM8952.